### PR TITLE
Correção arvore binaria

### DIFF
--- a/projetos/Aula7/arvoreBinaria/src/main/java/one/digitalinnovation/ArvoreBinaria.java
+++ b/projetos/Aula7/arvoreBinaria/src/main/java/one/digitalinnovation/ArvoreBinaria.java
@@ -1,139 +1,152 @@
 package one.digitalinnovation;
 
+import java.io.PrintStream;
+
 public class ArvoreBinaria<T extends Comparable<T>> {
 
-    private BinNo<T> raiz;
+	private BinNode<T> raiz;
 
-    public ArvoreBinaria(){
-        this.raiz = null;
-    }
+	public ArvoreBinaria() {
+		this.raiz = null;
+	}
 
-    public void inserir(T conteudo){
-        BinNo<T> novoNo = new BinNo<>(conteudo);
-        raiz = inserir(raiz, novoNo);
-    }
+	public void inserir(T conteudo) {
+		BinNode<T> novoNo = new BinNode<>(conteudo);
+		raiz = inserirNode(raiz, novoNo);
+	}
 
-    private BinNo<T> inserir(BinNo<T> atual, BinNo<T> novoNo){
-        if(atual == null){
-            return novoNo;
-        }else if(novoNo.getConteudo().compareTo(atual.getConteudo()) < 0){
-            atual.setNoEsq(inserir(atual.getNoEsq(), novoNo));
-        }else{
-            atual.setNoDir(inserir(atual.getNoDir(), novoNo));
-        }
-        return atual;
-    }
+	private BinNode<T> inserirNode(BinNode<T> atual, BinNode<T> novoNo) {
+		if (atual == null) {
+			return novoNo;
+		} else if (novoNo.getConteudo().compareTo(atual.getConteudo()) < 0) {
+			atual.setNoEsq(inserirNode(atual.getNoEsq(), novoNo));
+		} else {
+			atual.setNoDir(inserirNode(atual.getNoDir(), novoNo));
+		}
+		return atual;
+	}
 
-    public void exibirInOrdem(){
-        System.out.println("\n Exibindo InOrdem");
-        exibirInOrdem(this.raiz);
-    }
+	public void exibirInOrdem() {
+		System.out.println("\nExibindo InOrdem");
+		exibirInOrdem(this.raiz);
+	}
 
-    private void exibirInOrdem(BinNo<T> atual){
-        if(atual != null){
-            exibirInOrdem(atual.getNoEsq());
-            System.out.print(atual.getConteudo() + ", ");
-            exibirInOrdem(atual.getNoDir());
-        }
-    }
+	private void exibirInOrdem(BinNode<T> atual) {
+		if (atual != null) {
+			exibirInOrdem(atual.getNoEsq());
+			System.out.print(atual.getConteudo() + ", ");
+			exibirInOrdem(atual.getNoDir());
+		}
+	}
 
-    public void exibirPosOrdem(){
-        System.out.println("\n Exibindo PosOrdem");
-        exibirPosOrdem(this.raiz);
-    }
+	public void exibirPosOrdem() {
+		System.out.println("\nExibindo PosOrdem");
+		exibirPosOrdem(this.raiz);
+	}
 
-    private void exibirPosOrdem(BinNo<T> atual){
-        if(atual != null){
-            exibirPosOrdem(atual.getNoEsq());
-            exibirPosOrdem(atual.getNoDir());
-            System.out.print(atual.getConteudo() + ", ");
-        }
-    }
+	private void exibirPosOrdem(BinNode<T> atual) {
+		if (atual != null) {
+			exibirPosOrdem(atual.getNoEsq());
+			exibirPosOrdem(atual.getNoDir());
+			System.out.print(atual.getConteudo() + ", ");
+		}
+	}
 
-    public void exibirPreOrdem(){
-        System.out.println("\n Exibindo PreOrdem");
-        exibirPreOrdem(this.raiz);
-    }
+	public void exibirPreOrdem() {
+		System.out.println("\nExibindo PreOrdem");
+		exibirPreOrdem(this.raiz);
+	}
 
-    private void exibirPreOrdem(BinNo<T> atual){
-        if(atual != null){
-            System.out.print(atual.getConteudo() + ", ");
-            exibirPreOrdem(atual.getNoEsq());
-            exibirPreOrdem(atual.getNoDir());
-        }
-    }
+	private void exibirPreOrdem(BinNode<T> atual) {
+		if (atual != null) {
+			System.out.print(atual.getConteudo() + ", ");
+			exibirPreOrdem(atual.getNoEsq());
+			exibirPreOrdem(atual.getNoDir());
+		}
+	}
 
-    public void remover(T conteudo){
-        try{
-            BinNo<T> atual = this.raiz;
-            BinNo<T> pai = null;
-            BinNo<T> filho = null;
-            BinNo<T> temp = null;
+	// Método para chamada de remoção de nós
+	public void remover(T conteudo) {
+		raiz = removerNode(raiz, conteudo);
+	}
 
-            while (atual != null && !atual.getConteudo().equals(conteudo)){
-                pai = atual;
-                if(conteudo.compareTo(atual.getConteudo()) < 0){
-                    atual = atual.getNoEsq();
-                }else {
-                    atual = atual.getNoDir();
-                }
-            }
+	// Encontrar o elemento mínimo da subárvore
+	private T minimumElement(BinNode<T> atual) {
+		while (atual.getNoDir() != null)
+			atual = atual.getNoDir();
+		return atual.getConteudo();
+	}
 
-            if(atual == null){
-                System.out.println("Conteudo nao encontrado. Bloco Try");
-            }
+	private BinNode<T> removerNode(BinNode<T> atual, T conteudo) {
+		if (atual == null)
+			return null;
+		else if (conteudo.compareTo(atual.getConteudo()) < 0)
+			atual.setNoEsq(removerNode(atual.getNoEsq(), conteudo));
+		else if (conteudo.compareTo(atual.getConteudo()) > 0)
+			atual.setNoDir(removerNode(atual.getNoDir(), conteudo));
+		else {
+			if (atual.getNoEsq() == null && atual.getNoDir() == null)
+				return null;
+			else if (atual.getNoDir() == null)
+				return atual.getNoEsq();
+			else if (atual.getNoEsq() == null)
+				return atual.getNoDir();
+			else {
+				atual.setConteudo(minimumElement(atual.getNoEsq()));
+				atual.setNoEsq(removerNode(atual.getNoEsq(), atual.getConteudo()));
+			}
+		}
+		return atual;
+	}
 
-            if(pai == null){
-                if(atual.getNoDir() == null){
-                    this.raiz = atual.getNoEsq();
-                }else if(atual.getNoEsq() == null){
-                    this.raiz = atual.getNoDir();
-                }else {
-                    for(temp = atual, filho = atual.getNoEsq();
-                        filho.getNoDir() != null;
-                        temp = filho, filho = filho.getNoEsq()
-                    ){
-                        if(filho != atual.getNoEsq()){
-                            temp.setNoDir(filho.getNoEsq());
-                            filho.setNoEsq(raiz.getNoEsq());
-                        }
-                    }
-                    filho.setNoDir(raiz.getNoDir());
-                    raiz = filho;
-                }
-            }else if(atual.getNoDir() == null){
-                if(pai.getNoEsq() == atual){
-                    pai.setNoEsq(atual.getNoEsq());
-                }else {
-                    pai.setNoDir(atual.getNoEsq());
-                }
-            }else if(atual.getNoEsq() == null){
-                if(pai.getNoEsq() == atual){
-                    pai.setNoEsq(atual.getNoDir());
-                }else {
-                    pai.setNoDir(atual.getNoDir());
-                }
-            }else{
-                for(
-                        temp = atual, filho = atual.getNoEsq();
-                        filho.getNoDir() != null;
-                        temp = filho, filho = filho.getNoDir()
-                ){
-                    if(filho != atual.getNoEsq()){
-                        temp.setNoDir(filho.getNoEsq());
-                        filho.setNoEsq(atual.getNoEsq());
-                    }
-                    filho.setNoDir(atual.getNoDir());
-                    if(pai.getNoEsq() == atual){
-                        pai.setNoEsq(filho);
-                    }else{
-                        pai.setNoDir(filho);
-                    }
-                }
-            }
-        }catch (NullPointerException erro){
-            System.out.println("Conteudo nao encontrado. Bloco Catch");
-        }
-    }
+	private String traversePreOrder(BinNode<T> root) {
+
+		if (root == null) {
+			return "";
+		}
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(root.getConteudo());
+
+		String pointerRight = "└──";
+		String pointerLeft = (root.getNoDir() != null) ? "├──" : "└──";
+
+		traverseNodes(sb, "", pointerLeft, root.getNoEsq(), root.getNoDir() != null);
+		traverseNodes(sb, "", pointerRight, root.getNoDir(), false);
+
+		return sb.toString();
+	}
+
+	private void traverseNodes(StringBuilder sb, String padding, String pointer, BinNode<T> node,
+			boolean hasRightSibling) {
+
+		if (node != null) {
+
+			sb.append("\n");
+			sb.append(padding);
+			sb.append(pointer);
+			sb.append(node.getConteudo());
+
+			StringBuilder paddingBuilder = new StringBuilder(padding);
+			if (hasRightSibling) {
+				paddingBuilder.append("│  ");
+			} else {
+				paddingBuilder.append("   ");
+			}
+
+			String paddingForBoth = paddingBuilder.toString();
+			String pointerRight = "└──";
+			String pointerLeft = (node.getNoDir() != null) ? "├──" : "└──";
+
+			traverseNodes(sb, paddingForBoth, pointerLeft, node.getNoEsq(), node.getNoDir() != null);
+			traverseNodes(sb, paddingForBoth, pointerRight, node.getNoDir(), false);
+
+		}
+
+	}
+
+	public void print(PrintStream os) {
+		os.print(traversePreOrder(raiz));
+	}
 
 }

--- a/projetos/Aula7/arvoreBinaria/src/main/java/one/digitalinnovation/Main.java
+++ b/projetos/Aula7/arvoreBinaria/src/main/java/one/digitalinnovation/Main.java
@@ -8,20 +8,26 @@ public class Main {
 
         ArvoreBinaria<Obj> minhaArvore = new ArvoreBinaria<>();
 
-        minhaArvore.inserir(new Obj(13));
-        minhaArvore.inserir(new Obj(10));
-        minhaArvore.inserir(new Obj(25));
-        minhaArvore.inserir(new Obj(2));
-        minhaArvore.inserir(new Obj(12));
-        minhaArvore.inserir(new Obj(20));
-        minhaArvore.inserir(new Obj(31));
-        minhaArvore.inserir(new Obj(29));
-        minhaArvore.inserir(new Obj(32));
-        minhaArvore.remover(new Obj(32));
-
-        minhaArvore.exibirInOrdem();
-        minhaArvore.exibirPreOrdem();
-        minhaArvore.exibirPosOrdem();
+		minhaArvore.inserir(new Obj(13));
+		minhaArvore.inserir(new Obj(10));
+		minhaArvore.inserir(new Obj(25));
+		minhaArvore.inserir(new Obj(2));
+		minhaArvore.inserir(new Obj(12));
+		minhaArvore.inserir(new Obj(20));
+		minhaArvore.inserir(new Obj(31));
+		minhaArvore.inserir(new Obj(29));
+		minhaArvore.exibirPreOrdem();
+		System.out.println("\n");
+		minhaArvore.print(System.out);
+		
+		// encontrado Bug em remover Nós que tenham filhos -- corrigido
+		minhaArvore.remover(new Obj(25));
+		minhaArvore.inserir(new Obj(33));
+		minhaArvore.inserir(new Obj(26));
+		System.out.println("\n");
+		minhaArvore.exibirPreOrdem();
+		System.out.println("\n");
+		minhaArvore.print(System.out);
 
     }
 


### PR DESCRIPTION
1- O método remover estava com problemas. Apagava somente nós que eram folhas.
    - Correção efetuada, usando recursividade para simplificação do método.

2- Adicionado mais um método de impressão que vai apresentar a árvore de uma forma mais visual.